### PR TITLE
Sort exception type in method's & constructor's signature for deterministic order

### DIFF
--- a/byte-buddy-dep/src/test/java/net/bytebuddy/description/method/AbstractMethodDescriptionTest.java
+++ b/byte-buddy-dep/src/test/java/net/bytebuddy/description/method/AbstractMethodDescriptionTest.java
@@ -28,6 +28,8 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.Map;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 import static net.bytebuddy.matcher.ElementMatchers.named;
 import static org.hamcrest.CoreMatchers.*;
@@ -276,11 +278,30 @@ public abstract class AbstractMethodDescriptionTest {
 
     @Test
     public void testToString() throws Exception {
-        assertThat(describe(firstMethod).toString(), is(firstMethod.toString()));
-        assertThat(describe(secondMethod).toString(), is(secondMethod.toString()));
-        assertThat(describe(thirdMethod).toString(), is(thirdMethod.toString()));
-        assertThat(describe(firstConstructor).toString(), is(firstConstructor.toString()));
-        assertThat(describe(secondConstructor).toString(), is(secondConstructor.toString()));
+        assertThat(normalizeMethodExceptions(describe(firstMethod).toString()), is(normalizeMethodExceptions(firstMethod.toString())));
+        assertThat(normalizeMethodExceptions(describe(secondMethod).toString()), is(normalizeMethodExceptions(secondMethod.toString())));
+        assertThat(normalizeMethodExceptions(describe(thirdMethod).toString()), is(normalizeMethodExceptions(thirdMethod.toString())));
+        assertThat(normalizeMethodExceptions(describe(firstConstructor).toString()), is(normalizeMethodExceptions(firstConstructor.toString())));
+        assertThat(normalizeMethodExceptions(describe(secondConstructor).toString()), is(normalizeMethodExceptions(secondConstructor.toString())));
+    }
+    
+    public String normalizeMethodExceptions(String methodDescription) {
+        // Match "throws exception1, exception2, ..." part of method description
+        Pattern pattern = Pattern.compile("throws\\s+([^,]+(?:,\\s*[^,]+)*)");
+        Matcher matcher = pattern.matcher(methodDescription);
+        
+        // Extract and sort exceptions.
+        String exceptionString = "";
+        if (matcher.find()) {
+            String exceptionsPart = matcher.group(1);
+            String[] exceptions = exceptionsPart.split(",");
+            for (int i = 0; i < exceptions.length; i++) {
+                exceptions[i] = exceptions[i].trim();
+            }
+            Arrays.sort(exceptions);
+            exceptionString = String.join(",", exceptions);
+        }
+        return matcher.replaceAll(exceptionString); 
     }
 
     @Test


### PR DESCRIPTION
**Issue:**
The test `AbstractMethodDescriptionTest.java.testToString` compares method (as well as constructor) signatures. However, the `toString()` method for `java.lang.reflect.Method` may not consistently return a deterministic string representation due to `java.lang.reflect.Method.getExceptions()` having an unspecified order in the return result. 

We used the [nondex tool](https://github.com/TestingResearchIllinois/NonDex) to identify this test failure. The inconsistency is related to the order of exception types listed in the throws clause within the method signatures. As there is no guarantee regarding the order of the returned exceptions, certain tests can fail due to differences in exception ordering.

**Solution:**
This pull request proposes a solution by sorting the exception types within methods' signatures before conducting the comparison. By doing so, we ensure a consistent and predictable order of exceptions, resolving the issues caused by mismatched exception listings in method signatures.

**Steps to reproduce:**
1) git clone https://github.com/raphw/byte-buddy
2) cd byte-buddy 
3) mvn install -pl byte-buddy-dep -am -DskipTests (BUILD SUCCESS) 
4) mvn -pl byte-buddy-dep  edu.illinois:nondex-maven-plugin:2.1.1:nondex -Dtest=net.bytebuddy.description.method.MethodDescriptionForLoadedTest#testToString (Prints out error)
```
[ERROR] Failures: 
[ERROR]   MethodDescriptionForLoadedTest>AbstractMethodDescriptionTest.testToString:280 
Expected: is "protected abstract java.lang.Object net.bytebuddy.description.method.AbstractMethodDescriptionTest$Sample.second(java.lang.String,long) throws java.lang.RuntimeException,java.io.IOException"
     but: was "protected abstract java.lang.Object net.bytebuddy.description.method.AbstractMethodDescriptionTest$Sample.second(java.lang.String,long) throws java.io.IOException,java.lang.RuntimeException"
```