### PR TITLE
Fixed test failures caused by non-deterministic get exceptions methods

### DIFF
--- a/byte-buddy-dep/src/main/java/net/bytebuddy/description/type/TypeList.java
+++ b/byte-buddy-dep/src/main/java/net/bytebuddy/description/type/TypeList.java
@@ -38,6 +38,7 @@ import java.lang.reflect.TypeVariable;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Comparator;
 
 /**
  * Implementations represent a list of type descriptions.
@@ -1012,10 +1013,20 @@ public interface TypeList extends FilterableList<TypeDescription, TypeList> {
                 @Override
                 @CachedReturnPlugin.Enhance("resolved")
                 protected TypeDescription.Generic resolve() {
-                    java.lang.reflect.Type[] type = method.getGenericExceptionTypes();
+                    java.lang.reflect.Type[] type = sortTypes(method.getGenericExceptionTypes());
                     return erasure.length == type.length
                             ? Sort.describe(type[index], getAnnotationReader())
                             : asRawType();
+                }
+
+                java.lang.reflect.Type[] sortTypes(java.lang.reflect.Type[] type) {
+                    Arrays.sort(type, new Comparator<java.lang.reflect.Type>() {
+                        @Override
+                        public int compare(java.lang.reflect.Type type1, java.lang.reflect.Type type2) {
+                            return type1.toString().compareTo(type2.toString());
+                        }
+                    });
+                    return type;
                 }
 
                 /**

--- a/byte-buddy-dep/src/test/java/net/bytebuddy/description/method/AbstractMethodDescriptionTest.java
+++ b/byte-buddy-dep/src/test/java/net/bytebuddy/description/method/AbstractMethodDescriptionTest.java
@@ -28,6 +28,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.Map;
+import java.util.Comparator;
 
 import static net.bytebuddy.matcher.ElementMatchers.named;
 import static org.hamcrest.CoreMatchers.*;
@@ -608,13 +609,23 @@ public abstract class AbstractMethodDescriptionTest {
         assertThat(describe(firstMethod).getExceptionTypes(),
                 is((TypeList.Generic) new TypeList.Generic.ForLoadedTypes(firstMethod.getExceptionTypes())));
         assertThat(describe(secondMethod).getExceptionTypes(),
-                is((TypeList.Generic) new TypeList.Generic.ForLoadedTypes(secondMethod.getExceptionTypes())));
+                is((TypeList.Generic) new TypeList.Generic.ForLoadedTypes(sortExceptions(secondMethod.getExceptionTypes()))));
         assertThat(describe(thirdMethod).getExceptionTypes(),
                 is((TypeList.Generic) new TypeList.Generic.ForLoadedTypes(thirdMethod.getExceptionTypes())));
         assertThat(describe(firstConstructor).getExceptionTypes(),
                 is((TypeList.Generic) new TypeList.Generic.ForLoadedTypes(firstConstructor.getExceptionTypes())));
         assertThat(describe(secondConstructor).getExceptionTypes(),
                 is((TypeList.Generic) new TypeList.Generic.ForLoadedTypes(secondConstructor.getExceptionTypes())));
+    }
+
+    private Class<?>[] sortExceptions(Class<?>[] exceptionTypes) {
+        Arrays.sort(exceptionTypes, new Comparator<Class<?>>() {
+            @Override
+            public int compare(Class<?> type1, Class<?> type2) {
+                return type1.getName().compareTo(type2.getName());
+            }
+        });
+        return exceptionTypes;
     }
 
     @Test


### PR DESCRIPTION
Test failure found here: [testExceptions()](https://github.com/RugvedB/byte-buddy/blob/master/byte-buddy-dep/src/test/java/net/bytebuddy/description/method/AbstractMethodDescriptionTest.java#L607)
Tool used: I used non-dex tool to find this test failure.


**Issue 1. Duplicate elements:**
The resolve method [here](https://github.com/RugvedB/byte-buddy/blob/master/byte-buddy-dep/src/main/java/net/bytebuddy/description/type/TypeList.java#L1014) was using the java's non-deterministic `method.getGenericExceptionTypes()` which didn't guarantee the order of elements returned. Due to this, there is a possibility that the `type[index] `could return unexpected exception type and this leads to incorrect formation of exceptions array. In the error message below we see that `java.io.IOException` is appearing twice due to this issue. To fix this, we should sort the Type array returned by method.getGenericExceptionTypes() to make it deterministic.

```
Error Message:
"[ERROR] Failures:
[ERROR] MethodDescriptionLatentTest>AbstractMethodDescriptionTest.testExceptions:610
Expected: is <[class java.io.IOException, class java.lang.RuntimeException]>
but: was <[class java.io.IOException, class java.io.IOException]>"
```

<br>

**Issue 2. Non-deterministic order of java.lang.reflect.Method.getExceptionTypes()**
One additional step needs to done to fix the test failure completely. In the error below, we could see that there are no duplicates but the order of exceptions is shuffled. This is due to the fact that the order of exception types is not guaranteed by `java.lang.reflect.Method.getExceptionTypes()`. To fix this issue, we need to sort the the exception types to ensure deterministic behavior.

```
Error Message:
[ERROR] Failures:
[ERROR] MethodDescriptionForLoadedTest>AbstractMethodDescriptionTest.testExceptions:610
Expected: is <[class java.lang.RuntimeException, class java.io.IOException]>
but: was <[class java.io.IOException, class java.lang.RuntimeException]>
```

To summarize, to compare a method's exception types we are making sure that before comparing, both the expected and actual value are fetched in a deterministic way.