### PR TITLE
Added condition to handle case when value=null

### DIFF
--- a/byte-buddy-dep/src/main/java/net/bytebuddy/description/annotation/AnnotationValue.java
+++ b/byte-buddy-dep/src/main/java/net/bytebuddy/description/annotation/AnnotationValue.java
@@ -2511,7 +2511,7 @@ public interface AnnotationValue<T, S> {
             }
             AnnotationValue<?, ?> annotationValue = (AnnotationValue<?, ?>) other;
             Object value = annotationValue.resolve();
-            if (!value.getClass().isArray()) {
+            if (value == null || !value.getClass().isArray()) {
                 return false;
             }
             if (values.size() != Array.getLength(value)) {


### PR DESCRIPTION
Test failed: `testEquals` ([link](https://github.com/RugvedB/byte-buddy/blob/master/byte-buddy-dep/src/test/java/net/bytebuddy/description/annotation/AbstractAnnotationDescriptionTest.java#L290))
Tool used to find this test failure: nondex
```
[ERROR] Errors: 
[ERROR]   AnnotationDescriptionForLoadedAnnotationTest>AbstractAnnotationDescriptionTest.testEquals:290 » NullPointer
```

The `gerDeclaredMethods` method ([line](https://github.com/RugvedB/byte-buddy/blob/master/byte-buddy-dep/src/main/java/net/bytebuddy/description/type/TypeDescription.java#L8939)) returns non-deterministic result. For a certain combination of list returned by gerDeclaredMethods, AnnotationValue.java's ForDescriptionArray class' equals method is called. It has the following lines of code:
```
Object value = annotationValue.resolve();
if (!value.getClass().isArray()) {
    return false;
}
``` 
After analyzing the codebase, I have confirmed that the value variable can be null due to which the `value.getClass()` throws null pointer exception. In case the value variable is null, the equals method should return false and thus, we can fix this code by adding a null check as follows.
```
Object value = annotationValue.resolve();
if (value == null || !value.getClass().isArray()) {
    return false;
}
``` 
This change fixes the error and test passes successfully.